### PR TITLE
A lot of fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ system-install: stage3_extracted snapshot_extracted
 stage3_extracted: | $(root_dir)/usr/bin/emerge-webrsync #among others...
 
 $(root_dir)/usr/bin/emerge-webrsync: | $(dist_dir)/$(stage3_name) $(root_dir)
-	tar xpjf $< --xattrs-include='*.*' --numeric-owner -C $(root_dir)
+	tar xpjf $(dist_dir)/$(stage3_name) --xattrs-include='*.*' --numeric-owner -C $(root_dir)
 
 $(dist_dir)/$(stage3_name): | $(dist_dir)
 	curl $(distfiles_stage3)/$(stage3_subdir) -o $@

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,10 @@ $(progress_tmp_dir)/boot_mounted: $(progress_tmp_dir)/root_mounted | $(progress_
 	mount $(partition_1) $(root_dir)/boot
 	touch $@
 
-.PHONY: flash-umount
-flash-umount:
-	umount -q $(root_dir)
-	umount -q $(root_dir)/boot
-	rm $<
-
+.PHONY: disk-umount
+disk-umount: $(progress_tmp_dir)/root_mounted $(progress_tmp_dir)/boot_mounted
+	umount -Rq $(root_dir)
+	rm -f $^
 
 ## SYSTEM INSTALL ##
 
@@ -170,8 +168,7 @@ boot-install:
 ## CLEAN ##
 
 .PHONY: clean
-clean:
-	umount -Rq $(root_dir)
+clean: disk-umount 
 	rm -rf $(progress_dir)
 	rm -rf $(progress_tmp_dir)
 	rm -rf $(dist_dir)

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,14 @@ snapshot_extracted: | $(root_dir)/var/db/repos/gentoo
 
 $(root_dir)/var/db/repos/gentoo: chroot-ready | $(root_dir)/usr/bin/emerge-webrsync
 	chroot $(root_dir) /usr/bin/emerge-webrsync
-	echo 'FEATURES="$${FEATURES} -pid-sandbox"' >> $(root_dir)/etc/portage/make.conf
+	echo '\n# Bypass bugs in qemu-chrooting\nFEATURES="$${FEATURES} -pid-sandbox"' >> $(root_dir)/etc/portage/make.conf
+
+
+## BOOT INSTALL ## 
+
+.PHONY: boot-install
+boot-install:
+	@echo not implemented
 
 
 ### CHROOT ###
@@ -156,13 +163,6 @@ $(root_dir)/usr/bin/qemu-$(qemu_arch): | /usr/bin/qemu-$(qemu_arch)
 
 /usr/bin/qemu-$(qemu_arch):
 	emerge $(qemu_atom)
-
-
-## BOOT INSTALL ## 
-
-.PHONY: boot-install
-boot-install:
-	@echo not implemented
 
 
 ## CLEAN ##

--- a/Makefile
+++ b/Makefile
@@ -2,122 +2,178 @@ ARCH ?= arm64
 FLASH_DEV ?= /dev/mmcblk0
 
 help:
-	@echo build a gentoo system to run on a raspberry pi
+	@echo 'Build a gentoo system to run on a raspberry pi'
 	@echo
-	@echo some target of interest:
-	@echo '    chroot         build the system and chroot into'
-	@echo '    flash-init     create the layout and filesystems'
-	@echo '    flash-mount    mount the device to the root directory'
-	@echo some variables of interest:
+	@echo Some target of interest:
+	@echo '    disk-prepare create the label, paritions and filesystems'
+	@echo '    disk-mount     mount the root and boot partitions' 
+	@echo '    system-install install stage3 and snapshot'
+	@echo '    chroot         chroot into the system'
+	@echo '    boot-install   populate /boot'
+	@echo 'Some variables of interest:'
 	@echo '    ARCH           arch to use, one of {arm,arm64}, currently $(ARCH)'
 	@echo '    FLASH_DEV      path to flash device, currently $(FLASH_DEV)'
-	@echo
-	@echo the first steps for a first use would be
-	@echo '    $(MAKE) flash-init flash-mount chroot'
-	@echo you probably now want to configure around, setup make.conf, start to emerge stuff,
-	@echo such as sys-boot/raspberrypi-firmware
-	@echo then, when happy with it, umount it and go use it
-	@echo '    $(MAKE) flash-umount'
-	@echo if after some testing, you want to change something, use
-	@echo '    $(MAKE) flash-mount chroot'
+	@echo 'For a first you would start with:'
+	@echo '    $(MAKE) disk-prepare disk-mount system-install'
+	@echo 'You can them chroot using "$(MAKE) chroot" to setup the system:'
+	@echo 'Refer to the handbook to sync and choose a profile'
+	@echo 'and choose a profile among:'
+	@echo 'eselect profile list'
+	@echo 'Finally you can freshen the system using:'
+	@echo 'emerge --ask --verbose --emptytree --complete-graph=y @world'
+	@echo 'Once done, unchroot and install the boot'
+	@echo 'such as sys-boot/raspberrypi-firmware'
+	@echo 'When finished you can umount using:'
+	@echo '    $(MAKE) disk-umount'
+	@echo 'And chroot again another time with:'
+	@echo '    $(MAKE) disk-mount chroot'
 
+ifeq ($(findstring $(ARCH), arm arm64),)
+$(error unknow arch, available architectures are arm and arm64)
+endif
 
 progress_dir ?= .progress
 progress_tmp_dir ?= /tmp/rastoo
 dist_dir ?= distdir
 root_dir ?= root
 
-ifeq ($(findstring $(ARCH),arm arm64),)
-$(error unknow arch)
-endif
-ifeq ($(ARCH),arm)
-stage3_arch := armv6j
-qemu_arch := arm
-endif
-ifeq ($(ARCH),arm64)
-stage3_arch := armv7a
-qemu_arch := aarch64
 
-$(progress_dir)/arm64_rebuild: chroot-ready
-	@echo because there is no pre built stage3 for arm64, we rebuild most of it
-	chroot $(root_dir) emerge -e @system
+### DISK PREPARATION ###
+
+.PHONY: disk-prepare
+disk-prepare: $(progress_dir)/partitioned_disk $(progress_dir)/fs_installed
+
+$(progress_dir)/partitioned_disk: | $(progress_dir)
+	parted -s $(FLASH_DEV) -- \
+		mklabel gpt \
+		mkpart boot 0% 512MiB \
+		set 1 esp on \
+		mkpart root 512Mib 100%
 	touch $@
 
-chroot: $(progress_dir)/arm64_rebuild
-endif
-
-distfiles := http://distfiles.gentoo.org/
-distfiles_stage3 := $(distfiles)/releases/arm/autobuilds
-stage3_subdir := $(firstword $(shell curl -s "$(distfiles_stage3)/latest-stage3-$(stage3_arch)_hardfp.txt" | tail -n1))
-stage3_name := $(notdir $(stage3_subdir))
-portage_name := portage-latest.tar.bz2
-
-$(dist_dir) $(progress_dir) $(progress_tmp_dir) $(root_dir):
+$(progress_dir) $(progress_tmp_dir) $(root_dir) $(dist_dir):
 	mkdir -p $@
+
+/usr/sbin/mkfs.f2fs:
+	emerge sys-fs/f2fs-tools
+
+partition_1 = $$(lsblk -nl -o PATH $(FLASH_DEV) | sed '2q;d')
+partition_2 = $$(lsblk -nl -o PATH $(FLASH_DEV) | sed '3q;d')
+
+$(progress_dir)/fs_installed: /usr/sbin/mkfs.f2fs | $(progress_dir)/partitioned_disk
+	$< -f $(partition_1) 
+	$< -f $(partition_2) 
+	touch $@
+
+
+## MOUNT / UMOUNT ##
+
+.PHONY: disk-mount
+disk-mount: $(progress_tmp_dir)/root_mounted $(progress_tmp_dir)/boot_mounted
+
+$(progress_tmp_dir)/root_mounted: | $(progress_tmp_dir) $(root_dir)
+	mount $(partition_2) $(root_dir)
+	touch $@
+
+$(progress_tmp_dir)/boot_mounted: $(progress_tmp_dir)/root_mounted | $(progress_tmp_dir)
+	mkdir -p $(root_dir)/boot
+	mount $(partition_1) $(root_dir)/boot
+	touch $@
+
+.PHONY: flash-umount
+flash-umount:
+	umount -q $(root_dir)
+	umount -q $(root_dir)/boot
+	rm $<
+
+
+## SYSTEM INSTALL ##
+
+distfiles := http://distfiles.gentoo.org
+ifeq ($(ARCH), arm)
+	stage3_arch := armv6j
+	qemu_arch := arm
+	distfiles_stage3 := $(distfiles)/releases/arm/autobuilds
+	stage3_subdir := $(firstword $(shell curl -s "$(distfiles_stage3)/latest-stage3-$(stage3_arch)_hardfp.txt" | tail -n1))
+endif
+ifeq ($(ARCH), arm64)
+	stage3_arch := arm64
+	qemu_arch := aarch64
+	distfiles_stage3 := $(distfiles)/experimental/arm64
+	stage3_subdir := stage3-arm64-20190613.tar.bz2
+endif
+stage3_name := $(notdir $(stage3_subdir))
+
+.PHONY: system-install
+system-install: stage3_extracted snapshot_extracted
+
+.PHONY: stage3_extracted
+stage3_extracted: | $(root_dir)/usr/bin/emerge-webrsync #among others...
+
+$(root_dir)/usr/bin/emerge-webrsync: | $(dist_dir)/$(stage3_name) $(root_dir)
+	tar xpjf $< --xattrs-include='*.*' --numeric-owner -C $(root_dir)
+
 $(dist_dir)/$(stage3_name): | $(dist_dir)
 	curl $(distfiles_stage3)/$(stage3_subdir) -o $@
-$(dist_dir)/$(portage_name): | $(dist_dir)
-	curl $(distfiles)/snapshots/$(portage_name) -o $@
 
-$(progress_dir)/stage3_extracted: $(dist_dir)/$(stage3_name) | $(progress_dir) $(root_dir)
-	tar xpjf $< -C $(root_dir)
-	touch $@
-$(progress_dir)/portage_extracted: $(dist_dir)/$(portage_name) | $(progress_dir)/stage3_extracted
-	tar xpjf $< -C $(root_dir)/usr
-	touch $@
+.PHONY: snapshot_extracted
+snapshot_extracted: | $(root_dir)/var/db/repos/gentoo
+
+$(root_dir)/var/db/repos/gentoo: chroot-ready | $(root_dir)/usr/bin/emerge-webrsync
+	chroot $(root_dir) /usr/bin/emerge-webrsync
+	echo 'FEATURES="$${FEATURES} -pid-sandbox"' >> $(root_dir)/etc/portage/make.conf
+
+
+### CHROOT ###
 
 qemu_atom := app-emulation/qemu[qemu_user_targets_$(qemu_arch),static-user]
-/usr/bin/qemu-$(qemu_arch):
-	emerge $(qemu_atom)
-$(root_dir)/usr/bin/qemu-$(qemu_arch): | /usr/bin/qemu-$(qemu_arch) $(progress_dir)/portage_extracted
-	quickpkg $(qemu_atom)
-	ROOT=$(root_dir) emerge --usepkgonly --oneshot --nodeps $(qemu_atom)
 
-/proc/sys/fs/binfmt_misc:
-	$(error need a kernel with CONFIG_BINFMT_MISC=y)
-$(progress_tmp_dir)/qemu-binfmt_started: | $(progress_tmp_dir) $(root_dir)/usr/bin/qemu-$(qemu_arch) /proc/sys/fs/binfmt_misc
-	rc-service qemu-binfmt start
-	touch $@
-$(progress_tmp_dir)/root_subdir_mounted: | $(progress_tmp_dir) $(progress_dir)/stage3_extracted
+.PHONY: chroot
+chroot: chroot-ready 
+	chroot $(root_dir) /bin/bash
+
+.PHONY: chroot-ready
+chroot-ready: $(root_dir)/etc/resolv.conf $(progress_tmp_dir)/root_subdir_mounted | stage3_extracted $(progress_tmp_dir)/qemu-binfmt_started $(root_dir)/usr/bin/qemu-$(qemu_arch)
+
+$(root_dir)/etc/resolv.conf: /etc/resolv.conf | stage3_extracted
+	cp --dereference $< $@
+
+$(progress_tmp_dir)/root_subdir_mounted: | $(progress_tmp_dir) stage3_extracted
 	mount -o bind /dev $(root_dir)/dev
 	mount -o bind /proc $(root_dir)/proc
 	mount -o bind /sys $(root_dir)/sys
 	mount -o rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 devpts $(root_dir)/dev/pts -t devpts
 	touch $@
-$(root_dir)/etc/resolv.conf: /etc/resolv.conf | $(progress_dir)/stage3_extracted
-	cp $< $@
 
-.PHONY: chroot-ready
-chroot-ready: $(root_dir)/etc/resolv.conf $(progress_tmp_dir)/root_subdir_mounted | $(progress_tmp_dir)/qemu-binfmt_started
-
-.PHONY: chroot
-chroot: chroot-ready
-	chroot $(root_dir) /bin/bash
-
-
-.PHONY: flash-init
-flash-init: $(progress_dir)/flash_parted
-
-$(progress_dir)/flash_layouted: | $(progress_dir)
-	echo g  n 1 '' +512M  t 1  n 2 '' ''  t 2 23  w | \
-		tr ' ' '\n' | fdisk $(FLASH_DEV)
-	touch $@
-/usr/sbin/mkfs.f2fs:
-	emerge sys-fs/f2fs-tools
-$(progress_dir)/flash_parted: /usr/sbin/mkfs.f2fs | $(progress_dir)/flash_layouted
-	$< $(FLASH_DEV)p1
-	$< $(FLASH_DEV)p2
+$(progress_tmp_dir)/qemu-binfmt_started: | $(progress_tmp_dir) /proc/sys/fs/binfmt_misc
+	rc-service qemu-binfmt start
 	touch $@
 
+/proc/sys/fs/binfmt_misc:
+	$(error need a kernel with CONFIG_BINFMT_MISC=y)
 
-.PHONY: flash-mount
-flash-mount: $(progress_tmp_dir)/flash_mounted
-$(progress_tmp_dir)/flash_mounted: | $(progress_tmp_dir)
-	mount $(FLASH_DEV)p2 $(root_dir)
-	mount $(FLASH_DEV)p1 $(root_dir)/boot
-	touch $@
-.PHONY: flash-umount
-flash-umount: $(progress_tmp_dir)/flash_mounted
-	mount $(root_dir)
-	mount $(root_dir)/boot
-	rm $<
+$(root_dir)/usr/bin/qemu-$(qemu_arch): | /usr/bin/qemu-$(qemu_arch)
+	quickpkg $(qemu_atom)
+	ROOT=$(root_dir) emerge --usepkgonly --oneshot --nodeps $(qemu_atom)
+
+/usr/bin/qemu-$(qemu_arch):
+	emerge $(qemu_atom)
+
+
+## BOOT INSTALL ## 
+
+.PHONY: boot-install
+boot-install:
+	@echo not implemented
+
+
+## CLEAN ##
+
+.PHONY: clean
+clean:
+	umount -Rq $(root_dir)
+	rm -rf $(progress_dir)
+	rm -rf $(progress_tmp_dir)
+	rm -rf $(dist_dir)
+	rm -rf $(root_dir)
+


### PR DESCRIPTION
A lot of changes, not all of them have to be kept (and I probably forget some):
- I wasn't able to chroot, the way I made it work is to use an experimental stage3 for arm64. However I couldn't find a way to download the latest so the version is **fixed** in the makefile ):
- I solved the issue of /dev/sde1 and /dev/mmcblk0p1 using lsblk to list the partitions
- Instead of injecting characters in fdisk, I use parted which is way more reliable. I didn't do a target a target for _/usr/sbin/parted_ though...
- The snapshot is download after chroot is ready using the recommended _emerge-webrsync_
- Use tar _xpjf with args --xattrs-include='*.*' --numeric-owner_ as in the handbook
- Force mkfs to create filesystems
- Create boot folder to be able to mount the corresponding partition
- _make umount_ simply try to unmount everything quietly in $(root_dir)
- added _make system-install_, _make clean_ and rename a few things
- The _make help_ is not finished
- _FLASH_DEV_ should be renamed